### PR TITLE
Fix `locate` module to be faster

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tesswcs"
-version = "1.1.6"
+version = "1.1.7"
 description = ""
 authors = ["Christina Hedges <christina.l.hedges@nasa.gov>"]
 readme = "docs/README.md"

--- a/src/tesswcs/__init__.py
+++ b/src/tesswcs/__init__.py
@@ -3,7 +3,7 @@ import os  # noqa
 
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 
 # Standard library
 import logging  # noqa: E402

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -61,9 +61,7 @@ def test_pixel_location_skycoord_array():
     # Time is in Sector 6, targets are TOI-700, L 98-59, and SN 1987 A
     # TOI-700 and SN 1987 A were observed in Sector 6, L 98-59 was not
     t = Time(2458489.8075233004, format="jd")
-    coordinates = ["97.09679 -65.57931",
-                   "124.53176 -68.313",
-                   "83.86658 -69.2696"]
+    coordinates = ["97.09679 -65.57931", "124.53176 -68.313", "83.86658 -69.2696"]
     c = SkyCoord(coordinates, frame="icrs", unit=u.deg)
 
     pixel_locations = get_pixel_locations(c, time=t)
@@ -78,5 +76,3 @@ def test_pixel_location_skycoord_array():
     assert pixel_locations["Camera"][1] == 4
     assert pixel_locations["CCD"][1] == 3
     assert pixel_locations["Target Index"][1] == 2
-
-


### PR DESCRIPTION
In order to be accurate I made it so we used the `footprint_contains` function in astropy. This was a significant slow down as it had to step through each coordinate. It turns out this is effectively just calling `all_wcs2pix` for every coordinate until it breaks.

This version adds in a better way of checking if coordinates fall on pixels. 

This also merges @mrtommyb's unit test PR which was very important in making this work...!