### PR TITLE
resolve #11

### DIFF
--- a/src/tesswcs/tesswcs.py
+++ b/src/tesswcs/tesswcs.py
@@ -69,14 +69,18 @@ class WCS(astropyWCS):
             )
             return wcs
         else:
+            if sector not in pointings["Sector"]:
+                raise ValueError(
+                    f"Sector {sector} does not yet have predicted pointing information."
+                )
             log.warning(
                 f"Data for Sector {sector} has not been archived yet. This function will return the predicted WCS for Sector {sector}."
             )
             ra, dec, roll = [
                 i
-                for i in pointings[pointings["Sector"] == 3][["RA", "Dec", "Roll"]][
-                    0
-                ].values()
+                for i in pointings[pointings["Sector"] == sector][
+                    ["RA", "Dec", "Roll"]
+                ][0].values()
             ]
             wcs = cls.predict(
                 ra=ra, dec=dec, roll=roll, camera=camera, ccd=ccd, warp=True


### PR DESCRIPTION
This should resolve #11. It looks like [this line](https://github.com/tessgi/tesswcs/blob/a0638d880569ae99d79eddd2d7c4fc1723e374fb/src/tesswcs/tesswcs.py#L77) is currently accidentally forcing `from_sector` to return the WCS based on the predicted pointing for Sector 3 whenever the function is called for a sector that hasn't yet been archived. I also added a check to make sure the requested sector has a predicted pointing in the `tesswcs.pointings` table. Let me know if this looks ok!