### PR TITLE
Fixed non-functional documentation typos

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -385,7 +385,7 @@ for camera in np.arange(1, 5):
 
 ## Creating a WCS based on an RA, Dec, and Roll
 
-Sometimes we may want to obtain a WCS for a theoretical pointing of the spacecraft. To do so you can easily add your own boresight RA, Dec, and Roll. Below I show the same proceedure as above for a random pointing.
+Sometimes we may want to obtain a WCS for a theoretical pointing of the spacecraft. To do so you can easily add your own boresight RA, Dec, and Roll. Below I show the same procedure as above for a random pointing.
 
 
 ```python

--- a/docs/tutorial2.md
+++ b/docs/tutorial2.md
@@ -1,6 +1,6 @@
 # Using `tesswcs` to find observable targets
 
-`tesswcs` has some convenience functions to help you find out which targets are observable with TESS. The `get_pixel_locations` functon will accept sky coordinates, and return a table of which sector, camera, CCD, row, and column those targets fall on (if any). 
+`tesswcs` has some convenience functions to help you find out which targets are observable with TESS. The `get_pixel_locations` function will accept sky coordinates, and return a table of which sector, camera, CCD, row, and column those targets fall on (if any). 
 
 Let's take a look at how to use it. 
 

--- a/docs/tutorial2.md
+++ b/docs/tutorial2.md
@@ -262,7 +262,7 @@ confirmed_exoplanets_table[target_index]
 
 ## Example 2: Finding whether a transient will be observable with TESS
 
-Sometimes we might find an interesting transient, and we want to know whether it will fall on a TESS pixel so that we can recover the optical time-series when the data is downlinked. For example, [GRB 231106A](https://gcn.nasa.gov/circulars/34956) occured in November 2023 and happened to be observable during the TESS survey. 
+Sometimes we might find an interesting transient, and we want to know whether it will fall on a TESS pixel so that we can recover the optical time-series when the data is downlinked. For example, [GRB 231106A](https://gcn.nasa.gov/circulars/34956) occurred in November 2023 and happened to be observable during the TESS survey. 
 
 Here we show how we would find out if a transient has been (or will be) observable with TESS. 
 


### PR DESCRIPTION
This PR cleans up several misspellings and inconsistent wording.

### Updates:
- `docs/tutorial.md`, line 388: `proceedure` → `procedure`
- `docs/tutorial2.md`, line 3: `functon` → `function`
- `docs/tutorial2.md`, line 265: `occured` → `occurred`

The logic and functionality of the code remain unaffected.